### PR TITLE
Adding missing arch to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You also need a rust compiler which can compile for the iOS targets. If you use 
 ```sh
 rustup target add aarch64-apple-ios
 rustup target add armv7-apple-ios
+rustup target add armv7s-apple-ios
 rustup target add i386-apple-ios
 rustup target add x86_64-apple-ios
 ```


### PR DESCRIPTION
Readme was missing `armv7s-apple-ios`
