### PR TITLE
Support xcode install action

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-lipo"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Tim Neumann <mail@timnn.me>"]
 description = "cargo lipo subcommand to automatically create universal libraries for iOS"
 edition = "2018"

--- a/integration.bats.sh
+++ b/integration.bats.sh
@@ -110,3 +110,10 @@ setup() {
     check_archs x86_64 workspace/target/universal/release/libstatic2build.a
     check_archs x86_64 workspace/target/universal/release/libstatic3bin.a
 }
+
+@test "xcode install debug for simulator" {
+    xcode "clean install" Debug
+    check_archs x86_64 workspace/target/universal/debug/libstatic1.a
+    check_archs x86_64 workspace/target/universal/debug/libstatic2build.a
+    check_archs x86_64 workspace/target/universal/debug/libstatic3bin.a
+}

--- a/src/xcode.rs
+++ b/src/xcode.rs
@@ -13,7 +13,7 @@ pub(crate) fn integ(meta: &Meta, mut invocation: Invocation) -> Result<()> {
     let cargo = crate::cargo::Cargo::new(&invocation);
 
     match env::var("ACTION").with_context(|e| format!("Failed to read $ACTION: {}", e))?.as_str() {
-        "build" => {
+        "build" | "install" => {
             crate::lipo::build(&cargo, meta, &targets_from_env()?)?;
         }
         action => warn!("Unsupported XCode action: {:?}", action),


### PR DESCRIPTION
Carthage `build` uses the xcode `install` action, this adds support for it.

This patch has been tested with our own workflow:
```
git clone --branch cargo-lipo-3 https://github.com/mozilla/application-services.git
cd application-services/components/fxa-client/
carthage build --no-skip-current --verbose
```

which runs the following XCode "Run Script":
`cargo lipo --xcode-integ --package fxaclient_ffi --manifest-path ../Cargo.toml`