### PR TITLE
Check if the universal library is updated before running lipo

### DIFF
--- a/src/lipo.rs
+++ b/src/lipo.rs
@@ -5,6 +5,18 @@ use failure::ResultExt;
 use log::info;
 use std::fs;
 use std::process::Command;
+use std::path::Path;
+
+fn is_output_updated(output: impl AsRef<Path>, inputs: impl IntoIterator<Item=impl AsRef<Path>>) -> std::io::Result<bool> {
+    let output_mtime = fs::metadata(output)?.modified()?;
+    for input in inputs {
+        let input_mtime = fs::metadata(input)?.modified()?;
+        if input_mtime > output_mtime {
+            return Ok(false)
+        }
+    }
+    Ok(true)
+}
 
 pub(crate) fn build(cargo: &Cargo, meta: &Meta, targets: &[impl AsRef<str>]) -> Result<()> {
     for package in meta.packages() {
@@ -37,13 +49,18 @@ pub(crate) fn build(cargo: &Cargo, meta: &Meta, targets: &[impl AsRef<str>]) -> 
 
         output.push(&lib_name);
 
-        let mut cmd = Command::new("lipo");
-        cmd.arg("-create").arg("-output").arg(output);
-        cmd.args(inputs);
+        if let Ok(true) = is_output_updated(&output, &inputs) {
+            info!("Universal library for {} is updated", package.name());
+        }
+        else {
+            let mut cmd = Command::new("lipo");
+            cmd.arg("-create").arg("-output").arg(output);
+            cmd.args(inputs);
 
-        info!("Creating universal library for {}", package.name());
+            info!("Creating universal library for {}", package.name());
 
-        crate::exec::run(cmd)?;
+            crate::exec::run(cmd)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This PR checks if the universal library is updated by comparing the mtime of it to the inputs.

If I am working on the non-rust part of an Xcode project, everytime I hit the run button `cargo-lipo` runs. In this case I expect the `cargo-lipo` to finish quickly since everything in rust is updated,  but it takes noticeable time, because of the `lipo` command. This PR solves this problem by doing a Makefile-style check before running `lipo`.
