### PR TITLE
Enable CI for pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,10 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
       # Just check compilations on platforms other than stable.
-      - run: |
+      # Note that we have to explicitly exclude stable, because `cargo clippy`
+      # after `cargo check` does not work properly: https://github.com/rust-lang/rust-clippy/issues/4612
+      - if: matrix.rust == 'stable'
+        run: |
           cargo check --all --manifest-path ./Cargo.toml
       # Only run the stable versions of Clippy and rustfmt.
       - if: matrix.rust == 'stable'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,14 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           # Only install the components on stable (might not be available on nightly).
           components: rustfmt, clippy
       - if: matrix.rust != 'stable'
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
       # Just check compilations on platforms other than stable.
       - run: |
           cargo check --all --manifest-path ./Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+    branches: master
   pull_request:
   schedule:
     - cron: '21 3 ? * 6'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '21 3 ? * 6'
 


### PR DESCRIPTION
cc @messense: I've cherry-picked this from your #47, thanks!

Additional changes:

* Only run for pushes to `master`.
* Fix the toolchain version selection (it was hardcoded to `stable` instead of referring to the matrix variable).
* Don't run `cargo check` on stable, because it breaks `cargo clippy` running afterwards.